### PR TITLE
Eig2D Solver speed up: use float64 and eigsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist/
 .vscode/
 
 
+example/mmf_radial_fix.py
+example/pymmf_performance.ipynb
+example/pymmf_eig_performance.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/
 example/mmf_radial_fix.py
 example/pymmf_performance.ipynb
 example/pymmf_eig_performance.ipynb
+example/pymmf_eig_performance.py
+example/pymmf_performance.py

--- a/pyMMF/core.py
+++ b/pyMMF/core.py
@@ -104,7 +104,10 @@ def estimateNumModesGRIN(wl,a,NA,pola=1):
     '''
     k0 = 2.*np.pi/wl
     V = k0*a*NA
-    return np.ceil(V**2/4.*pola/2.).astype(int)
+    nmodes = np.ceil(V**2/4.*pola/2.).astype(int)
+    logger.info(f'Estimated {nmodes} modes.')
+    return nmodes
+
 
 def estimateNumModesSI(wl,a,NA,pola=1):
     '''
@@ -129,7 +132,9 @@ def estimateNumModesSI(wl,a,NA,pola=1):
     '''
     k0 = 2.*np.pi/wl
     V = k0*a*NA
-    return np.ceil(V**2/2.*pola/2.).astype(int)
+    nmodes = np.ceil(V**2/2.*pola/2.).astype(int)
+    logger.info(f'Estimated {nmodes} modes.')
+    return nmodes
 
    
 
@@ -195,7 +200,7 @@ class propagationModeSolver():
             'eig' solves the eigenvalue problem in the discretized space.
             'SI' solves numerically the analytical dispersion relation and approximate modes to LP modes.
             'default' use the best appropriate solver.
-            detauls to 'default'
+            default to 'default'
         **options: dict
             specific options for the solver
 		    
@@ -283,7 +288,7 @@ class propagationModeSolver():
         
     def get_optimal_solver(self, curvature):
         if self.indexProfile.type == 'SI' and not curvature:
-            logger.info('Selectinf step-index solver')
+            logger.info('Selecting step-index solver')
             return 'SI'
         elif self.indexProfile.radialFunc is not None:
             logger.info('Selectinf axisymmetric radial solver')

--- a/pyMMF/functions.py
+++ b/pyMMF/functions.py
@@ -7,35 +7,32 @@ Created on Mon Feb  4 12:02:57 2019
 """
 
 import numpy as np
-from scipy.special import jv, kn
 import logging
 
 
 logger = logging.getLogger(__name__)
 
+
 def cart2pol(X, Y):
     '''
-	Returns the angular and radial matrices (polar coordinates) correspondng to the input cartesian matrices X and Y.
-	
-	Parameters
-	----------
-	
-	X : numpy array
-		matrix corresponding to the first Cartesian coordinate
-	Y :  numpy array
-		matrix corresponding to the second Cartesian coordinate
-		
-	Returns
-	-------
-	
-	TH : numpy array
-		matrix corresponding to the theta coordinate
-	R : numpy array
-		matrix corresponding to the radial coordinate
+        Returns the angular and radial matrices (polar coordinates) correspondng to the input cartesian matrices X and Y.
+
+        Parameters
+        ----------
+
+        X : numpy array
+                matrix corresponding to the first Cartesian coordinate
+        Y :  numpy array
+                matrix corresponding to the second Cartesian coordinate
+
+        Returns
+        -------
+
+        TH : numpy array
+                matrix corresponding to the theta coordinate
+        R : numpy array
+                matrix corresponding to the radial coordinate
     '''
     TH = np.arctan2(Y, X)
     R = np.sqrt(X**2 + Y**2)
-    return (TH, R)   
-
-
-
+    return (TH, R)

--- a/pyMMF/index_profile.py
+++ b/pyMMF/index_profile.py
@@ -62,22 +62,27 @@ class IndexProfile():
         radialFunc = lambda r: n1 if r < a else n2
 
         self.initFromRadialFunction(radialFunc)
-        
+
     def initStepIndexMultiCore(
             self, n1: float = 1.45, a: float = 1., delta: float = 0.039,
             dims: int = 4, layers: int = 1,
-            NA: float = 0.4, core_offset: float = 5):
+            NA: float = 0.4, core_pitch: float = 5,
+            central_core: bool = True):
         n2 = n1 * (1 - delta)
         self.NA = NA
         self.a = a
         self.type = 'SIMC'
         self.n1 = n1
-        core_offset = int(core_offset // self.dh)
-        angles = np.arange(0, 2 * np.pi, 2 * np.pi / dims)
-        radiuses = np.arange(layers + 1) * core_offset
-        cores_coords = [[self.npoints // 2 + int(r * np.sin(t)),
-                         self.npoints // 2 + int(r * np.cos(t))]
-                        for r in radiuses for t in angles]
+        core_pitch = int(core_pitch // self.dh)
+        lgrid = np.arange(0 if central_core else 1, layers + 1)
+        angles = [
+            np.arange(0, 2 * np.pi, 2 * np.pi / dims / lnum) for lnum in lgrid]
+        radiuses = lgrid * core_pitch
+        cores_coords = [[
+            [self.npoints // 2 + int(r * np.sin(t)),
+             self.npoints // 2 + int(r * np.cos(t))]
+            for t in _a] for r, _a in zip(radiuses, angles)]
+        cores_coords = sum(cores_coords, [])
         self.n = np.ones_like(self.R) * n2
         for indxs in cores_coords:
             i, j = indxs
@@ -87,13 +92,13 @@ class IndexProfile():
 
     def initStepIndexConcentric(
             self, n1: float = 1.45, a: float = 1., delta: float = 0.039,
-            NA: float = 0.4, core_offset: float = 5, layers: int = 1):
+            NA: float = 0.4, core_pitch: float = 5, layers: int = 1):
         n2 = n1 * (1 - delta)
         self.NA = NA
         self.a = a
         self.type = 'SIC'
         self.n1 = n1
-        radiuses = np.arange(layers + 1) * core_offset
+        radiuses = np.arange(layers + 1) * core_pitch
 
         def radialFunc(r):
             for r0 in radiuses:
@@ -102,3 +107,19 @@ class IndexProfile():
             return n2
 
         self.initFromRadialFunction(radialFunc)
+
+    def initStepIndexMicrostructured(
+            self, n1: float = 1.45, a: float = 1.,
+            dims: int = 4, layers: int = 1,
+            NA: float = 0.4, core_pitch: float = 5,
+            cladding_radius: float = 25):
+        delta = 1 - n1
+        n2 = np.sqrt(n1**2-NA**2)
+        self.initStepIndexMultiCore(
+            1, a, delta, dims, layers, NA, core_pitch,
+            central_core=0)
+        self.type = 'MSF'
+        self._crop_cladding(n2, cladding_radius)
+
+    def _crop_cladding(self, n2, cladding_radius):
+        self.n[self.R > cladding_radius] = n2

--- a/pyMMF/index_profile.py
+++ b/pyMMF/index_profile.py
@@ -62,3 +62,22 @@ class IndexProfile():
         radialFunc = lambda r: n1 if r<a else n2
 		
         self.initFromRadialFunction(radialFunc)
+
+    def initSI4CoreIndex(self, n1: float = 1.45, a: float = 1., delta: float = 0.039,
+                         NA: float = 0.4, core_offset: float = 5):
+        n2 = n1 * (1 - delta)
+        self.NA = NA
+        self.a = a
+        self.type = 'SI'
+        self.n1 = n1
+        core_offset = int(core_offset // self.dh)
+        cores_coords = [[self.npoints // 2 + core_offset, self.npoints // 2],
+                        [self.npoints // 2 - core_offset, self.npoints // 2],
+                        [self.npoints // 2, self.npoints // 2 + core_offset],
+                        [self.npoints // 2, self.npoints // 2 - core_offset]]
+        self.n = np.ones_like(self.R) * n2
+        for indxs in cores_coords:
+            i, j = indxs
+            self.n[(self.X - self.X[i, j]) ** 2 +
+                   (self.Y - self.Y[i, j]) ** 2 < a] = n1
+        self.n.flatten()

--- a/pyMMF/index_profile.py
+++ b/pyMMF/index_profile.py
@@ -58,68 +58,7 @@ class IndexProfile():
         self.n1 = n1
         n2 = np.sqrt(n1**2-NA**2)
         #Delta = NA**2/(2.*n1**2)
-
-        radialFunc = lambda r: n1 if r < a else n2
-
-        self.initFromRadialFunction(radialFunc)
-
-    def initStepIndexMultiCore(
-            self, n1: float = 1.45, a: float = 1., delta: float = 0.039,
-            dims: int = 4, layers: int = 1,
-            NA: float = 0.4, core_pitch: float = 5,
-            central_core: bool = True):
-        n2 = n1 * (1 - delta)
-        self.NA = NA
-        self.a = a
-        self.type = 'SIMC'
-        self.n1 = n1
-        core_pitch = int(core_pitch // self.dh)
-        lgrid = np.arange(0 if central_core else 1, layers + 1)
-        angles = [
-            np.arange(0, 2 * np.pi, 2 * np.pi / dims / lnum) for lnum in lgrid]
-        radiuses = lgrid * core_pitch
-        cores_coords = [[
-            [self.npoints // 2 + int(r * np.sin(t)),
-             self.npoints // 2 + int(r * np.cos(t))]
-            for t in _a] for r, _a in zip(radiuses, angles)]
-        cores_coords = sum(cores_coords, [])
-        self.n = np.ones_like(self.R) * n2
-        for indxs in cores_coords:
-            i, j = indxs
-            self.n[np.sqrt((self.X - self.X[i, j]) ** 2 +
-                   (self.Y - self.Y[i, j]) ** 2) < a] = n1
-        self.n.flatten()
-
-    def initStepIndexConcentric(
-            self, n1: float = 1.45, a: float = 1., delta: float = 0.039,
-            NA: float = 0.4, core_pitch: float = 5, layers: int = 1):
-        n2 = n1 * (1 - delta)
-        self.NA = NA
-        self.a = a
-        self.type = 'SIC'
-        self.n1 = n1
-        radiuses = np.arange(layers + 1) * core_pitch
-
-        def radialFunc(r):
-            for r0 in radiuses:
-                if np.abs(r - r0) < a:
-                    return n1
-            return n2
+        
+        radialFunc = lambda r: n1 if r<a else n2
 
         self.initFromRadialFunction(radialFunc)
-
-    def initStepIndexMicrostructured(
-            self, n1: float = 1.45, a: float = 1.,
-            dims: int = 4, layers: int = 1,
-            NA: float = 0.4, core_pitch: float = 5,
-            cladding_radius: float = 25):
-        delta = 1 - n1
-        n2 = np.sqrt(n1**2-NA**2)
-        self.initStepIndexMultiCore(
-            1, a, delta, dims, layers, NA, core_pitch,
-            central_core=0)
-        self.type = 'MSF'
-        self._crop_cladding(n2, cladding_radius)
-
-    def _crop_cladding(self, n2, cladding_radius):
-        self.n[self.R > cladding_radius] = n2

--- a/pyMMF/solvers/SI.py
+++ b/pyMMF/solvers/SI.py
@@ -127,7 +127,7 @@ def calc_mode(modes, idx, degenerate_mode, R, a, TH,
     # Non-zero transverse component
     if degenerate_mode == 'sin':
         # two pi/2 rotated degenerate modes for m < 0
-        psi = np.pi/2 if m[idx] < 0 else 0 
+        psi = np.pi/2 if m < 0 else 0 
         phase_mult = np.cos(phase + psi)
 
     elif degenerate_mode == 'exp':

--- a/pyMMF/solvers/eig2D.py
+++ b/pyMMF/solvers/eig2D.py
@@ -74,7 +74,7 @@ def solve_eig(
         dh_npoints_x = [1./dh**2]*(npoints-1)
         bound_cond_x = (dh_npoints_x+[0.])*(npoints-1) + dh_npoints_x
         bound_cond_y = [1./dh**2]*npoints*(npoints-1)
-        
+
         if boundary == 'periodic':
             logger.info('Use periodic boundary condition.')
             diags.append(bound_cond_x)
@@ -109,7 +109,7 @@ def solve_eig(
             # - the term in (1-2*poisson_coeff) represent the effect of compression/dilatation
             # see http://wavefrontshaping.net/index.php/68-community/tutorials/multimode-fibers/149-multimode-fiber-modes-part-2
             xi = 1.-(index_flatten-1.)/index_flatten*(1.-2.*poisson)
-           
+
             # curv_mat = sparse.diags(1.-2*xi*self.indexProfile.X.flatten()/curvature, dtype = np.complex128)
             curv_inv_diag = 1.
             if curvature[0] is not None:
@@ -126,14 +126,16 @@ def solve_eig(
 
         if curvature:
             H = curv_mat.dot(H)
-        
+
         beta_min = k0*np.min(indexProfile.n)
         beta_max = k0*np.max(indexProfile.n)
 
         # Finds the eigenvalues of the operator with the greatest real part
         if is_hermitian(H):
+            logger.info('H is hermitian. Using `eigsh` to speed up a process.')
             eigvals, eigvecs = eigsh(H, k=nmodesMax, which='LM')
         else:
+            logger.info('H is not hermitian. Using `eigs`.')
             eigvals, eigvecs = eigs(H, k=nmodesMax, which='LR')
 
         modes = Modes()


### PR DESCRIPTION
Hi Sébastien!

I've noticed that ["The matrix  can be very large but it is also very sparse and Hermitian"](https://www.wavefrontshaping.net/post/id/3) and trying to speed up eig2d solver:
1. Because of H matrix structure we can use `np.float64` instead of `np.complex128`.
2. Because of H matrix is hermitian we can use `eigsh` instead of `eigh`

I added a function to check if H is hermitian and if it True, an algorithm uses  `eigsh` instead of `eigh`. Also I changed type of H to `np.float64`. It also needs because complex-number matrix generate small noise in imaginary part of `betas` and `profiles`, which is unphysicall.

My version is much faster and generates correct profiles, but some profiles are swapped because of small differences of `betas`. For example, these `betas` are swapped:
```python
new                 old
(14.62192877519683, (14.621928775196864-1.4871352228586787e-17j)),
(14.621928775196931, (14.621928775198063-3.882414689743801e-17j))
```

#### Performance graph
![image](https://user-images.githubusercontent.com/73311144/139530105-197dcaf6-18bb-4f5c-8e13-035bde1f8018.png)
